### PR TITLE
Creation ts

### DIFF
--- a/store/query.go
+++ b/store/query.go
@@ -291,8 +291,7 @@ func (r *Result) ToMap() (data map[string]interface{}) {
 	data["id"] = r.Id
 	data["kind"] = r.Kind
 	var ts_latest int64
-	var ts_oldest int64
-	ts_oldest = time.Now().UnixNano()
+	ts_oldest := time.Now().UnixNano()
 	for pred, versions := range r.Columns {
 		// During conversion to JSON, to keep things simple,
 		// we're dropping older versions of predicates, and
@@ -301,15 +300,15 @@ func (r *Result) ToMap() (data map[string]interface{}) {
 		data[pred] = versions.Latest().Value
 		if versions.Latest().NanoTs > ts_latest {
 			ts_latest = versions.Latest().NanoTs
-			data["source"] = versions.Latest().Source // Loss of information.
+			data["modifier"] = versions.Latest().Source // Loss of information.
 		}
 		if versions.Oldest().NanoTs < ts_oldest {
 			ts_oldest = versions.Oldest().NanoTs
 			data["creator"] = versions.Oldest().Source
 		}
 	}
-	data["creation_ts"] = int(ts_oldest / 1000000)
-	data["ts_millis"] = int(ts_latest / 1000000) // Loss of information. Picking up latest mod time.
+	data["creation_ms"] = int(ts_oldest / 1000000)
+	data["modification_ms"] = int(ts_latest / 1000000) // Loss of information. Picking up latest mod time.
 	kinds := make(map[string]bool)
 	for _, child := range r.Children {
 		kinds[child.Kind] = true

--- a/store/query.go
+++ b/store/query.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"sort"
+	"time"
 
 	"github.com/manishrjain/gocrud/x"
 )
@@ -289,19 +290,26 @@ func (r *Result) ToMap() (data map[string]interface{}) {
 	data = make(map[string]interface{})
 	data["id"] = r.Id
 	data["kind"] = r.Kind
-	var ts int64
+	var ts_latest int64
+	var ts_oldest int64
+	ts_oldest = time.Now().UnixNano()
 	for pred, versions := range r.Columns {
 		// During conversion to JSON, to keep things simple,
 		// we're dropping older versions of predicates, and
 		// source and ts information across all the predicates,
 		// keeping only the latest one.
 		data[pred] = versions.Latest().Value
-		if versions.Latest().NanoTs > ts {
-			ts = versions.Latest().NanoTs
+		if versions.Latest().NanoTs > ts_latest {
+			ts_latest = versions.Latest().NanoTs
 			data["source"] = versions.Latest().Source // Loss of information.
 		}
+		if versions.Oldest().NanoTs < ts_oldest {
+			ts_oldest = versions.Oldest().NanoTs
+			data["creator"] = versions.Oldest().Source
+		}
 	}
-	data["ts_millis"] = int(ts / 1000000) // Loss of information. Picking up latest mod time.
+	data["creation_ts"] = int(ts_oldest / 1000000)
+	data["ts_millis"] = int(ts_latest / 1000000) // Loss of information. Picking up latest mod time.
 	kinds := make(map[string]bool)
 	for _, child := range r.Children {
 		kinds[child.Kind] = true

--- a/store/query.go
+++ b/store/query.go
@@ -296,9 +296,9 @@ func (r *Result) ToMap() (data map[string]interface{}) {
 		// source and ts information across all the predicates,
 		// keeping only the latest one.
 		data[pred] = versions.Latest().Value
-		data["source"] = versions.Latest().Source // Loss of information.
 		if versions.Latest().NanoTs > ts {
 			ts = versions.Latest().NanoTs
+			data["source"] = versions.Latest().Source // Loss of information.
 		}
 	}
 	data["ts_millis"] = int(ts / 1000000) // Loss of information. Picking up latest mod time.

--- a/testx/store_test.go
+++ b/testx/store_test.go
@@ -50,7 +50,7 @@ func TestVersions(t *testing.T) {
 	type jval struct {
 		Kind   string `json:"kind,omitempty"`
 		Id     string `json:"id,omitempty"`
-		Source string `json:"source,omitempty"`
+		Source string `json:"modifier,omitempty"`
 		Price  int    `json:"price,omitempty"`
 	}
 	js, err := result.ToJson()


### PR DESCRIPTION
Hey @manishrjain! Thought I'd make this pull request, since the creator/creation_ts fields were really useful in our search indexer, I thought it'd be good to have them in all queries. What do you think? Also, while making this change I believe I caught a bug in `query.go:299`, where data["source"] is written to outside the timestamp comparison.
