### PR TITLE
Add check for empty query id

### DIFF
--- a/store/query.go
+++ b/store/query.go
@@ -268,6 +268,9 @@ func (q *Query) doRun(level, max int, ch chan runResult) {
 // Any errors encountered during these stpeps is returned as well.
 func (q *Query) Run() (result *Result, rerr error) {
 	q = q.root()
+	if len(q.id) == 0 {
+		return result, errors.New("Empty entity id")
+	}
 
 	ch := make(chan runResult)
 	go q.doRun(0, q.maxDepth, ch)


### PR DESCRIPTION
Right now `store.NewQuery("").Run()` gives undefined behavior. Let's catch this and return an error.
